### PR TITLE
podspec: Only try to build .swift files

### DIFF
--- a/CleanroomLogger.podspec
+++ b/CleanroomLogger.podspec
@@ -6,6 +6,6 @@ Pod::Spec.new do |s|
   s.author       = 'emaloney'
   s.source       = { :git => 'https://github.com/emaloney/CleanroomLogger.git', :tag => s.version }
   s.platform     = :ios, '9.0'
-  s.source_files = 'Sources/*'
+  s.source_files = 'Sources/*.swift'
   s.license = 'MIT'
 end


### PR DESCRIPTION
Fixes a warning for "no rule to process file README.md"